### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -60,7 +60,7 @@
         <h1 id="resources">Resources</h1>
         <ul>
         <li>http://www.uthcode.com/pythondesign.html#python-internals</li>
-        <li>http://greentreesnakes.readthedocs.org/en/latest/nodes.html</li>
+        <li>https://greentreesnakes.readthedocs.io/en/latest/nodes.html</li>
         <li>http://wiki.python.org/moin/PythonImplementations</li>
         <li>https://www.youtube.com/watch?v=XGF3Qu4dUqk</li>
         <li>http://www.python.org/dev/peps/pep-0339/</li>

--- a/resources.md
+++ b/resources.md
@@ -2,7 +2,7 @@ Resources
 =========
 
 - http://www.uthcode.com/pythondesign.html#python-internals
-- http://greentreesnakes.readthedocs.org/en/latest/nodes.html
+- https://greentreesnakes.readthedocs.io/en/latest/nodes.html
 - http://wiki.python.org/moin/PythonImplementations
 - https://www.youtube.com/watch?v=XGF3Qu4dUqk
 - http://www.python.org/dev/peps/pep-0339/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
