### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/research.html
+++ b/research.html
@@ -96,7 +96,7 @@
         </ul></li>
         <li>Simon Holm Jensen, Anders Møller, Peter Thiemann. “Interprocedural Analysis with Lazy Propagation”. SAS 2010.
         <ul>
-        <li>http://dx.doi.org/10.1007/978-3-642-15769-1_20</li>
+        <li>https://doi.org/10.1007/978-3-642-15769-1_20</li>
         <li>http://www.daimi.au.dk/~amoeller/papers/lazy/paper.pdf</li>
         </ul></li>
         <li>Dimitrios Vardoulakis and Olin Shivers. CFA2: a Context-Free Approach to Control-Flow Analysis. ESOP 2010

--- a/research.md
+++ b/research.md
@@ -47,7 +47,7 @@ Indirect Research
     * http://www.cs.wisc.edu/wpis/papers/popl95.pdf
 
 - Simon Holm Jensen, Anders Møller, Peter Thiemann. “Interprocedural Analysis with Lazy Propagation”. SAS 2010. 
-    * http://dx.doi.org/10.1007/978-3-642-15769-1_20
+    * https://doi.org/10.1007/978-3-642-15769-1_20
     * http://www.daimi.au.dk/~amoeller/papers/lazy/paper.pdf
 
 - Dimitrios Vardoulakis and Olin Shivers. CFA2: a Context-Free Approach to Control-Flow Analysis. ESOP 2010


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Because I noticed [its use already in several other parts of your code](https://github.com/search?q=org%3Apydata+https+doi&type=Code), I hereby suggest to update all other DOI links as well.

Cheers!